### PR TITLE
Update deployment environment naming

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -82,7 +82,7 @@ jobs:
     name: Deploy to Environment
     runs-on: ubuntu-latest
     environment:
-      name: ${{ contains(github.ref, 'main') && 'production' || contains(github.ref, 'develop') && 'development' || 'other' }}
+      name: ${{ contains(github.ref, 'main') && 'production' || contains(github.ref, 'develop') && 'staging' || 'other' }}
     defaults:
       run:
         shell: bash
@@ -93,9 +93,7 @@ jobs:
     steps:
       - name: Deploy
         run: |
-          echo "Deploy to Environment: $env_env_env"
-        env:
-          env_env_env: ${{ vars.ENV_NAME }}
+          echo "Deploy to Environment: ${{ vars.ENV_NAME }}"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
Changed the deployment environment from 'development' to 'staging' for the develop branch. Simplified echo command in the deploy step by directly using the variable instead of an intermediate environment variable.
